### PR TITLE
Access multiple ANC350s simultaneously.

### DIFF
--- a/example-v4.py
+++ b/example-v4.py
@@ -3,98 +3,98 @@
 #   by Brian Schaefer, adapted from pyanc-example.py by Rob Heath
 #
 
-from pyanc350.v4 import Positioner
+from pyanc350.v4 import discover, Positioner
 import time
 
-ax = {'x':0,'y':1,'z':2}
-#define a dict of axes to make things simpler
+ax = {'x': 0, 'y': 1, 'z': 2}
+# define a dict of axes to make things simpler
 
-anc = Positioner()
-#instantiate positioner as anc
-print('-------------------------------------------------------------')
-print('capacitances:')
-for axis in sorted(ax.keys()):
-    print(axis,anc.measureCapacitance(ax[axis]))
-    anc.setFrequency(ax[axis],200)
-    anc.setAmplitude(ax[axis],45)
+dev_count = discover()
 
-# print('-------------------------------------------------------------')
-# print('setting static amplitude to 2V')
-# anc.staticAmplitude(2000)
-# #set staticAmplitude to 2V to ensure accurate positioning info
-# staticAmplitude function does not exist in v4
-print('-------------------------------------------------------------')
-print('moving to x = 3mm')
-anc.setAxisOutput(ax['x'], 1, 0)
-anc.setTargetRange(ax['x'],1e-6)
-anc.setTargetPosition(ax['x'], 9e-3)
-anc.startAutoMove(ax['x'], 1, 0)
+if dev_count != 0:
+    anc = Positioner(0)
+    # instantiate positioner as anc
+    print('-------------------------------------------------------------')
+    print('capacitances:')
+    for axis in sorted(ax.keys()):
+        print(axis, anc.measureCapacitance(ax[axis]))
+        anc.setFrequency(ax[axis], 200)
+        anc.setAmplitude(ax[axis], 45)
 
-#check what's happening
-time.sleep(0.5)
-moving = 1
-target = 0
-while target == 0:
-    connected, enabled, moving, target, eotFwd, eotBwd, error = anc.getAxisStatus(ax['x']) #find bitmask of status
-    if target == 0:
-        print('axis moving, currently at',anc.getPosition(ax['x']))
-    elif target == 1:
-        print('axis arrived at',anc.getPosition(ax['x']))
-        anc.startAutoMove(ax['x'], 0, 0)
+    # print('-------------------------------------------------------------')
+    # print('setting static amplitude to 2V')
+    # anc.staticAmplitude(2000)
+    # #set staticAmplitude to 2V to ensure accurate positioning info
+    # staticAmplitude function does not exist in v4
+    print('-------------------------------------------------------------')
+    print('moving to x = 3mm')
+    anc.setAxisOutput(ax['x'], 1, 0)
+    anc.setTargetRange(ax['x'], 1e-6)
+    anc.setTargetPosition(ax['x'], 9e-3)
+    anc.startAutoMove(ax['x'], 1, 0)
+
+    # check what's happening
     time.sleep(0.5)
-    
+    moving = 1
+    target = 0
+    while target == 0:
+        connected, enabled, moving, target, eotFwd, eotBwd, error = anc.getAxisStatus(ax['x'])  # find bitmask of status
+        if target == 0:
+            print('axis moving, currently at', anc.getPosition(ax['x']))
+        elif target == 1:
+            print('axis arrived at', anc.getPosition(ax['x']))
+            anc.startAutoMove(ax['x'], 0, 0)
+        time.sleep(0.5)
 
-print('and moving y:')
-anc.setAxisOutput(ax['y'], 1, 0)
-anc.setTargetRange(ax['y'],1e-6)
-anc.setTargetPosition(ax['y'], 8e-3)
-anc.startAutoMove(ax['y'], 1, 0)
-time.sleep(0.5)
-target = 0
-while target == 0:
-    connected, enabled, moving, target, eotFwd, eotBwd, error = anc.getAxisStatus(ax['y']) #find bitmask of status
-    if target == 0:
-        print('axis moving, currently at',anc.getPosition(ax['y']))
-    elif target == 1:
-        print('axis arrived at',anc.getPosition(ax['y']))
-        anc.startAutoMove(ax['y'], 0, 0)
+    print('and moving y:')
+    anc.setAxisOutput(ax['y'], 1, 0)
+    anc.setTargetRange(ax['y'], 1e-6)
+    anc.setTargetPosition(ax['y'], 8e-3)
+    anc.startAutoMove(ax['y'], 1, 0)
     time.sleep(0.5)
-    
+    target = 0
+    while target == 0:
+        connected, enabled, moving, target, eotFwd, eotBwd, error = anc.getAxisStatus(ax['y'])  # find bitmask of status
+        if target == 0:
+            print('axis moving, currently at', anc.getPosition(ax['y']))
+        elif target == 1:
+            print('axis arrived at', anc.getPosition(ax['y']))
+            anc.startAutoMove(ax['y'], 0, 0)
+        time.sleep(0.5)
 
-    
-print('-------obtaining all possible gettable values for x---------')
-#get every possible gettable value
-print('getActuatorName',anc.getActuatorName(ax['x']))
-print('getActuatorType',anc.getActuatorType(ax['x']))
-print('getAmplitude',anc.getAmplitude(ax['x']))
-print('getAxisStatus',anc.getAxisStatus(ax['x']))
-print('getDeviceConfig',anc.getDeviceConfig())
-print('getDeviceInfo',anc.getDeviceInfo())
-print('getFirmwareVersion',anc.getFirmwareVersion())
-print('getFrequency',anc.getFrequency(ax['x']))
-print('getPosition',anc.getPosition(ax['x']))
-print('-------------------------------------------------------------')
+    print('-------obtaining all possible gettable values for x---------')
+    # get every possible gettable value
+    print('getActuatorName', anc.getActuatorName(ax['x']))
+    print('getActuatorType', anc.getActuatorType(ax['x']))
+    print('getAmplitude', anc.getAmplitude(ax['x']))
+    print('getAxisStatus', anc.getAxisStatus(ax['x']))
+    print('getDeviceConfig', anc.getDeviceConfig())
+    print('getDeviceInfo', anc.getDeviceInfo())
+    print('getFirmwareVersion', anc.getFirmwareVersion())
+    print('getFrequency', anc.getFrequency(ax['x']))
+    print('getPosition', anc.getPosition(ax['x']))
+    print('-------------------------------------------------------------')
 
-print('testing \'functions for manual positioning\'')
-anc.setFrequency(ax['x'],50)
-print('set frequency to 50Hz')
-for i in range(30):
-    anc.startSingleStep(ax['x'],0)
-    time.sleep(0.1)
-print('arrived at:',anc.getPosition(ax['x']),'after 30 pulses')
-anc.startContinuousMove(ax['x'],1, 0)
-print('waiting 3 seconds...')
-time.sleep(3)
-anc.startContinuousMove(ax['x'],0, 0)
-print('and stopped at',anc.getPosition(ax['x']))
-print('set frequency to 200Hz')
-anc.setFrequency(ax['x'],200)
-anc.startContinuousMove(ax['x'],1, 0)
-print('waiting 3 seconds...')
-time.sleep(3)
-anc.startContinuousMove(ax['x'],0, 0)
+    print('testing \'functions for manual positioning\'')
+    anc.setFrequency(ax['x'], 50)
+    print('set frequency to 50Hz')
+    for i in range(30):
+        anc.startSingleStep(ax['x'], 0)
+        time.sleep(0.1)
+    print('arrived at:', anc.getPosition(ax['x']), 'after 30 pulses')
+    anc.startContinuousMove(ax['x'], 1, 0)
+    print('waiting 3 seconds...')
+    time.sleep(3)
+    anc.startContinuousMove(ax['x'], 0, 0)
+    print('and stopped at', anc.getPosition(ax['x']))
+    print('set frequency to 200Hz')
+    anc.setFrequency(ax['x'], 200)
+    anc.startContinuousMove(ax['x'], 1, 0)
+    print('waiting 3 seconds...')
+    time.sleep(3)
+    anc.startContinuousMove(ax['x'], 0, 0)
 
-print('-------------------------------------------------------------')
-print('closing connection...')
-anc.disconnect()
-print('-------------------------------------------------------------')
+    print('-------------------------------------------------------------')
+    print('closing connection...')
+    anc.disconnect()
+    print('-------------------------------------------------------------')

--- a/pyanc350/v4/ANC350libv4.py
+++ b/pyanc350/v4/ANC350libv4.py
@@ -18,36 +18,38 @@
 #              http://nowack.lassp.cornell.edu/
 
 
-import ctypes, os, time
+import ctypes
+from pathlib import Path
 
 #
 # List of error types
 #
-ANC_Ok = 0 #                    No error
-ANC_Error = -1 #                Unknown / other error
-ANC_Timeout = 1 #               Timeout during data retrieval
-ANC_NotConnected = 2 #          No contact with the positioner via USB
-ANC_DriverError = 3 #           Error in the driver response
-ANC_DeviceLocked = 7 #          A connection attempt failed because the device is already in use
-ANC_Unknown = 8 # Unknown error.
-ANC_NoDevice = 9 # Invalid device number used in call
-ANC_NoAxis = 10 # Invalid axis number in function call
-ANC_OutOfRange = 11 # Parameter in call is out of range
-ANC_NotAvailable = 12 # Function not available for device type
+ANC_Ok = 0  # No error
+ANC_Error = -1  # Unknown / other error
+ANC_Timeout = 1  # Timeout during data retrieval
+ANC_NotConnected = 2  # No contact with the positioner via USB
+ANC_DriverError = 3  # Error in the driver response
+ANC_DeviceLocked = 7  # A connection attempt failed because the device is already in use
+ANC_Unknown = 8  # Unknown error.
+ANC_NoDevice = 9  # Invalid device number used in call
+ANC_NoAxis = 10  # Invalid axis number in function call
+ANC_OutOfRange = 11  # Parameter in call is out of range
+ANC_NotAvailable = 12  # Function not available for device type
 
-#checks the errors returned from the dll
-def checkError(code,func,args):
+
+# checks the errors returned from the dll
+def checkError(code, func, args):
     if code == ANC_Ok:
         return
-    elif code == ANC_Error:             
-        raise Exception("Error: unspecific in"+str(func.__name__)+"with parameters:"+str(args))
-    elif code == ANC_Timeout:           
-        raise Exception("Error: comm. timeout in"+str(func.__name__)+"with parameters:"+str(args))
-    elif code == ANC_NotConnected:      
-        raise Exception("Error: not connected") 
-    elif code == ANC_DriverError:       
-        raise Exception("Error: driver error") 
-    elif code == ANC_DeviceLocked:      
+    elif code == ANC_Error:
+        raise Exception("Error: unspecific in" + str(func.__name__) + "with parameters:" + str(args))
+    elif code == ANC_Timeout:
+        raise Exception("Error: comm. timeout in" + str(func.__name__) + "with parameters:" + str(args))
+    elif code == ANC_NotConnected:
+        raise Exception("Error: not connected")
+    elif code == ANC_DriverError:
+        raise Exception("Error: driver error")
+    elif code == ANC_DeviceLocked:
         raise Exception("Error: device locked")
     elif code == ANC_NoDevice:
         raise Exception("Error: invalid device number")
@@ -57,55 +59,50 @@ def checkError(code,func,args):
         raise Exception("Error: parameter out of range")
     elif code == ANC_NotAvailable:
         raise Exception("Error: function not available")
-    else:                    
-        raise Exception("Error: unknown in"+str(func.__name__)+"with parameters:"+str(args))
+    else:
+        raise Exception("Error: unknown in" + str(func.__name__) + "with parameters:" + str(args))
     return code
 
+
 # import dll - have to change directories so it finds libusb0.dll
-'''
-directory_of_this_module_and_dlls = os.path.dirname(os.path.realpath(__file__))
-current_directory = os.getcwd()
-os.chdir(directory_of_this_module_and_dlls)
-anc350v4 = ctypes.windll.LoadLibrary(directory_of_this_module_and_dlls+'\\anc350v4.dll')
-os.chdir(current_directory)
-'''
-anc350v4 = ctypes.windll.anc350v4
+d = Path(__file__).parent
+anc350v4 = ctypes.WinDLL(f'{d}\\anc350v4.dll')
 
-#aliases for the strangely-named functions from the dll
-discover = getattr(anc350v4,"ANC_discover")
-getDeviceInfo = getattr(anc350v4,"ANC_getDeviceInfo")
-connect = getattr(anc350v4,"ANC_connect")
-disconnect = getattr(anc350v4,"ANC_disconnect")
-getDeviceConfig = getattr(anc350v4,"ANC_getDeviceConfig")
-getAxisStatus = getattr(anc350v4,"ANC_getAxisStatus")
-setAxisOutput = getattr(anc350v4,"ANC_setAxisOutput")
-setAmplitude = getattr(anc350v4,"ANC_setAmplitude")
-setFrequency = getattr(anc350v4,"ANC_setFrequency")
-setDcVoltage = getattr(anc350v4,"ANC_setDcVoltage")
-getAmplitude = getattr(anc350v4,"ANC_getAmplitude")
-getFrequency = getattr(anc350v4,"ANC_getFrequency")
-startSingleStep = getattr(anc350v4,"ANC_startSingleStep")
-startContinousMove = getattr(anc350v4,"ANC_startContinousMove")
-startAutoMove = getattr(anc350v4,"ANC_startAutoMove")
-setTargetPosition = getattr(anc350v4,"ANC_setTargetPosition")
-setTargetRange = getattr(anc350v4,"ANC_setTargetRange")
-getPosition = getattr(anc350v4,"ANC_getPosition")
-getFirmwareVersion = getattr(anc350v4,"ANC_getFirmwareVersion")
-configureExtTrigger = getattr(anc350v4,"ANC_configureExtTrigger")
-configureAQuadBIn = getattr(anc350v4,"ANC_configureAQuadBIn")
-configureAQuadBOut = getattr(anc350v4,"ANC_configureAQuadBOut")
-configureRngTriggerPol = getattr(anc350v4,"ANC_configureRngTriggerPol")
-configureRngTrigger = getattr(anc350v4,"ANC_configureRngTrigger")
-configureRngTriggerEps = getattr(anc350v4,"ANC_configureRngTriggerEps")
-configureNslTrigger = getattr(anc350v4,"ANC_configureNslTrigger")
-configureNslTriggerAxis = getattr(anc350v4,"ANC_configureNslTriggerAxis")
-selectActuator = getattr(anc350v4,"ANC_selectActuator")
-getActuatorName = getattr(anc350v4,"ANC_getActuatorName")
-getActuatorType = getattr(anc350v4,"ANC_getActuatorType")
-measureCapacitance = getattr(anc350v4,"ANC_measureCapacitance")
-saveParams = getattr(anc350v4,"ANC_saveParams")
+# aliases for the strangely-named functions from the dll
+discover = getattr(anc350v4, "ANC_discover")
+getDeviceInfo = getattr(anc350v4, "ANC_getDeviceInfo")
+connect = getattr(anc350v4, "ANC_connect")
+disconnect = getattr(anc350v4, "ANC_disconnect")
+getDeviceConfig = getattr(anc350v4, "ANC_getDeviceConfig")
+getAxisStatus = getattr(anc350v4, "ANC_getAxisStatus")
+setAxisOutput = getattr(anc350v4, "ANC_setAxisOutput")
+setAmplitude = getattr(anc350v4, "ANC_setAmplitude")
+setFrequency = getattr(anc350v4, "ANC_setFrequency")
+setDcVoltage = getattr(anc350v4, "ANC_setDcVoltage")
+getAmplitude = getattr(anc350v4, "ANC_getAmplitude")
+getFrequency = getattr(anc350v4, "ANC_getFrequency")
+startSingleStep = getattr(anc350v4, "ANC_startSingleStep")
+startContinousMove = getattr(anc350v4, "ANC_startContinousMove")
+startAutoMove = getattr(anc350v4, "ANC_startAutoMove")
+setTargetPosition = getattr(anc350v4, "ANC_setTargetPosition")
+setTargetRange = getattr(anc350v4, "ANC_setTargetRange")
+getPosition = getattr(anc350v4, "ANC_getPosition")
+getFirmwareVersion = getattr(anc350v4, "ANC_getFirmwareVersion")
+configureExtTrigger = getattr(anc350v4, "ANC_configureExtTrigger")
+configureAQuadBIn = getattr(anc350v4, "ANC_configureAQuadBIn")
+configureAQuadBOut = getattr(anc350v4, "ANC_configureAQuadBOut")
+configureRngTriggerPol = getattr(anc350v4, "ANC_configureRngTriggerPol")
+configureRngTrigger = getattr(anc350v4, "ANC_configureRngTrigger")
+configureRngTriggerEps = getattr(anc350v4, "ANC_configureRngTriggerEps")
+configureNslTrigger = getattr(anc350v4, "ANC_configureNslTrigger")
+configureNslTriggerAxis = getattr(anc350v4, "ANC_configureNslTriggerAxis")
+selectActuator = getattr(anc350v4, "ANC_selectActuator")
+getActuatorName = getattr(anc350v4, "ANC_getActuatorName")
+getActuatorType = getattr(anc350v4, "ANC_getActuatorType")
+measureCapacitance = getattr(anc350v4, "ANC_measureCapacitance")
+saveParams = getattr(anc350v4, "ANC_saveParams")
 
-#set error checking & handling
+# set error checking & handling
 discover.errcheck = checkError
 connect.errcheck = checkError
 disconnect.errcheck = checkError

--- a/pyanc350/v4/PyANC350v4.py
+++ b/pyanc350/v4/PyANC350v4.py
@@ -2,17 +2,14 @@
 #  PyANC350v4 is a control scheme suitable for the Python coding style
 #    for the attocube ANC350 closed-loop positioner system.
 #
-#  It implements ANC350v4lib, which in turn depends on anc350v4.dll and libusb0.dll, which are provided by attocube in the
-#     ANC350_Library folder on the driver disc. Place all
+#  It implements ANC350v4lib, which in turn depends on anc350v4.dll and libusb0.dll, which are provided by attocube in
+#     the ANC350_Library folder on the driver disc. Place all
 #     of these in the same folder as this module (and that of ANC350lib).
 #     This should also work with anc350v3.dll, although this has not been thoroughly checked.
 #
 #  Unlike ANC350v4lib which is effectively a re-imagining of the
 #    C++ header, PyANC350v4 is intended to behave as one might expect
 #    Python to. This means: returning values; behaving as an object.
-#
-#  At present this only addresses the first ANC350 connected to the
-#    machine.
 #
 #  Usage:
 #  1. instantiate Positioner() class to begin, eg. pos = Positioner().
@@ -32,18 +29,35 @@
 #                         5-Jul-2016
 #              http://nowack.lassp.cornell.edu/
 
+import ctypes
 import pyanc350.v4.ANC350libv4 as ANC
-import ctypes, math
+
+
+def discover(ifaces=3):
+    """
+    The function searches for connected ANC350RES devices on USB and LAN and initializes internal data structures
+    per device. Devices that are in use by another application or PC are not found. The function must be called
+    before connecting to a device and must not be called as long as any devices are connected. The number of
+    devices found is returned. In subsequent functions, devices are identified by a sequence number that must be
+    less than the number returned. Parameters ifaces	Interfaces where devices are to be searched. {None: 0,
+    USB: 1, ethernet: 2, all:3} Default: 3 Returns devCount	number of devices found
+    """
+    devCount = ctypes.c_int()
+    ANC.discover(ifaces, ctypes.byref(devCount))
+    return devCount.value
+
 
 class Positioner:
-    
-    def __init__(self):
-        self.discover()
+
+    def __init__(self, devID=0):
+        self.id = devID
         self.device = self.connect()
-        
-        
+
+    def __del__(self):
+        self.disconnect()
+
     def configureAQuadBIn(self, axisNo, enable, resolution):
-        '''
+        """
         Enables and configures the A-Quad-B (quadrature) input for the target position.
         Parameters
             axisNo	Axis number (0 ... 2)
@@ -51,14 +65,12 @@ class Positioner:
             resolution	A-Quad-B step width in m. Internal resolution is 1 nm.
         Returns
             None
-        '''
+        """
         ANC.configureAQuadBIn(self.device, axisNo, enable, ctypes.c_double(resolution))
-        
-        
-    def configureAQuadBOut(self, axisNo, enable, resolution, clock):
-        '''
-        Enables and configures the A-Quad-B output of the current position.
 
+    def configureAQuadBOut(self, axisNo, enable, resolution, clock):
+        """
+        Enables and configures the A-Quad-B output of the current position.
         Parameters
             axisNo	Axis number (0 ... 2)
             enable	Enable (1) or disable (0) A-Quad-B output
@@ -66,175 +78,136 @@ class Positioner:
             clock	Clock of the A-Quad-B output [s]. Allowed range is 40ns ... 1.3ms; internal resulution is 20ns.
         Returns/
             None
-        '''
+        """
         ANC.configureAQuadBOut(self.device, axisNo, enable, ctypes.c_double(resolution), ctypes.c_double(clock))
-       
-    
-    def configureExtTrigger(self, axisNo, mode):
-        '''
-        Enables the input trigger for steps.
 
+    def configureExtTrigger(self, axisNo, mode):
+        """
+        Enables the input trigger for steps.
         Parameters
             axisNo	Axis number (0 ... 2)
             mode	Disable (0), Quadratur (1), Trigger(2) for external triggering
         Returns
             None
-        '''
+        """
         ANC.configureExtTrigger(self.device, axisNo, mode)
-     
-    
-    def configureNslTrigger(self, enable):
-        '''
-        Enables NSL Input as Trigger Source.
 
+    def configureNslTrigger(self, enable):
+        """
+        Enables NSL Input as Trigger Source.
         Parameters
             enable	disable(0), enable(1)
         Returns
             None
-        '''
+        """
         ANC.configureNslTrigger(self.device, enable)
-    
-    
-    def configureNslTriggerAxis(self, axisNo):
-        '''
-        Selects Axis for NSL Trigger.
 
+    def configureNslTriggerAxis(self, axisNo):
+        """
+        Selects Axis for NSL Trigger.
         Parameters
             axisNo	Axis number (0 ... 2)
         Returns
             None
-        '''
+        """
         ANC.configureNslTriggerAxis(self.device, axisNo)
-      
-    
-    def configureRngTrigger(self, axisNo, lower, upper):
-        '''
-        Configure lower position for range Trigger.
 
+    def configureRngTrigger(self, axisNo, lower, upper):
+        """
+        Configure lower position for range Trigger.
         Parameters
             axisNo	Axis number (0 ... 2)
             lower	Lower position for range trigger (nm)
             upper	Upper position for range trigger (nm)
         Returns
             None
-        '''
+        """
         ANC.configureRngTrigger(self.device, axisNo, lower, upper)
-       
-    
-    def configureRngTriggerEps(self, axisNo, epsilon):
-        '''
-        Configure hysteresis for range Trigger.
 
+    def configureRngTriggerEps(self, axisNo, epsilon):
+        """
+        Configure hysteresis for range Trigger.
         Parameters
             axisNo	Axis number (0 ... 2)
             epsilon	hysteresis in nm / mdeg
         Returns
             None
-        '''
+        """
         ANC.configureRngTriggerEps(self.device, axisNo, epsilon)
-        
-        
-    def configureRngTriggerPol(self, axisNo, polarity):
-        '''
-        Configure lower position for range Trigger.
 
+    def configureRngTriggerPol(self, axisNo, polarity):
+        """
+        Configure lower position for range Trigger.
         Parameters
             axisNo	Axis number (0 ... 2)
             polarity	Polarity of trigger signal when position is between lower and upper Low(0) and High(1)
         Returns
             None
-        '''
+        """
         ANC.configureRngTriggerPol(self.device, axisNo, polarity)
-       
-    
-    def connect(self, devNo=0):
-        '''
-        Initializes and connects the selected device. This has to be done before any access to control variables or measured data.
 
+    def connect(self):
+        """
+        Initializes and connects the selected device. This has to be done before any access to control variables or measured data.
         Parameters
             devNo	Sequence number of the device. Must be smaller than the devCount from the last ANC_discover call. Default: 0
         Returns
             device	Handle to the opened device, NULL on error
-        '''
+        """
         device = ctypes.c_void_p()
-        ANC.connect(devNo, ctypes.byref(device))
+        ANC.connect(self.id, ctypes.byref(device))
         return device
-        
-        
+
     def disconnect(self):
-        '''
+        """
         Closes the connection to the device. The device handle becomes invalid.
-
         Parameters
             None
         Returns
             None
-        '''
+        """
         ANC.disconnect(self.device)
-       
-    
-    def discover(self, ifaces=3):
-        '''
-        The function searches for connected ANC350RES devices on USB and LAN and initializes internal data structures per device. Devices that are in use by another application or PC are not found. The function must be called before connecting to a device and must not be called as long as any devices are connected.
 
-        The number of devices found is returned. In subsequent functions, devices are identified by a sequence number that must be less than the number returned.
-
-        Parameters
-            ifaces	Interfaces where devices are to be searched. {None: 0, USB: 1, ethernet: 2, all:3} Default: 3
-        Returns
-            devCount	number of devices found
-        '''
-        devCount = ctypes.c_int()
-        ANC.discover(ifaces, ctypes.byref(devCount))
-        return devCount.value
-    
-    
     def getActuatorName(self, axisNo):
-        '''
+        """
         Get the name of the currently selected actuator
-
         Parameters
             axisNo	Axis number (0 ... 2)
         Returns
             name	Name of the actuator
-        '''
+        """
         name = ctypes.create_string_buffer(20)
         ANC.getActuatorName(self.device, axisNo, ctypes.byref(name))
         return name.value.decode('utf-8')
-        
-        
-    def getActuatorType(self, axisNo):
-        '''
-        Get the type of the currently selected actuator
 
+    def getActuatorType(self, axisNo):
+        """
+        Get the type of the currently selected actuator
         Parameters
             axisNo	Axis number (0 ... 2)
         Returns
             type_	Type of the actuator {0: linear, 1: goniometer, 2: rotator}
-        '''
+        """
         type_ = ctypes.c_int()
         ANC.getActuatorType(self.device, axisNo, ctypes.byref(type_))
         return type_.value
-       
-        
+
     def getAmplitude(self, axisNo):
-        '''
+        """
         Reads back the amplitude parameter of an axis.
-        
+
         Parameters
             axisNo	Axis number (0 ... 2)
         Returns
             amplitude	Amplitude V
-        '''
+        """
         amplitude = ctypes.c_double()
         ANC.getAmplitude(self.device, axisNo, ctypes.byref(amplitude))
         return amplitude.value
-    
-    
-    def getAxisStatus(self, axisNo):
-        '''
-        Reads status information about an axis of the device.
 
+    def getAxisStatus(self, axisNo):
+        """
+        Reads status information about an axis of the device.
         Parameters
             axisNo	Axis number (0 ... 2)
         Returns
@@ -245,7 +218,7 @@ class Positioner:
             eotFwd	Output: If end of travel detected in forward direction.
             eotBwd	Output: If end of travel detected in backward direction.
             error	Output: If the axis' sensor is in error state.
-        '''
+        """
         connected = ctypes.c_int()
         enabled = ctypes.c_int()
         moving = ctypes.c_int()
@@ -254,14 +227,13 @@ class Positioner:
         eotBwd = ctypes.c_int()
         error = ctypes.c_int()
 
-        ANC.getAxisStatus(self.device, axisNo, ctypes.byref(connected), ctypes.byref(enabled), ctypes.byref(moving), ctypes.byref(target), ctypes.byref(eotFwd), ctypes.byref(eotBwd), ctypes.byref(error))
+        ANC.getAxisStatus(self.device, axisNo, ctypes.byref(connected), ctypes.byref(enabled), ctypes.byref(moving),
+                          ctypes.byref(target), ctypes.byref(eotFwd), ctypes.byref(eotBwd), ctypes.byref(error))
         return connected.value, enabled.value, moving.value, target.value, eotFwd.value, eotBwd.value, error.value
-    
-    
-    def getDeviceConfig(self):
-        '''
-        Reads static device configuration data
 
+    def getDeviceConfig(self):
+        """
+        Reads static device configuration data
         Parameters
             None
         Returns
@@ -269,22 +241,20 @@ class Positioner:
             featureLockin	"Lockin": Low power loss measurement enabled (1) or disabled (0)
             featureDuty	"Duty": Duty cycle enabled (1) or disabled (0)
             featureApp	"App": Control by IOS app enabled (1) or disabled (0)
-        '''
+        """
         features = ctypes.c_int()
         ANC.getDeviceConfig(self.device, features)
-        
-        featureSync = 0x01&features.value
-        featureLockin = (0x02&features.value)/2
-        featureDuty = (0x04&features.value)/4
-        featureApp = (0x08&features.value)/8
-        
+
+        featureSync = 0x01 & features.value
+        featureLockin = (0x02 & features.value) / 2
+        featureDuty = (0x04 & features.value) / 4
+        featureApp = (0x08 & features.value) / 8
+
         return featureSync, featureLockin, featureDuty, featureApp
 
-    
-    def getDeviceInfo(self, devNo=0):
-        '''
+    def getDeviceInfo(self):
+        """
         Returns available information about a device. The function can not be called before ANC_discover but the devices don't have to be connected . All Pointers to output parameters may be zero to ignore the respective value.
-
         Parameters
             devNo	Sequence number of the device. Must be smaller than the devCount from the last ANC_discover call. Default: 0
         Returns
@@ -293,89 +263,78 @@ class Positioner:
             serialNo	Output: The device's serial number. The string buffer should be NULL or at least 16 bytes long.
             address	Output: The device's interface address if applicable. Returns the IP address in dotted-decimal notation or the string "USB", respectively. The string buffer should be NULL or at least 16 bytes long.
             connected	Output: If the device is already connected
-        '''
+        """
         devType = ctypes.c_int()
         id_ = ctypes.c_int()
-        serialNo = ctypes.create_string_buffer(16) 
-        address = ctypes.create_string_buffer(16) 
+        serialNo = ctypes.create_string_buffer(16)
+        address = ctypes.create_string_buffer(16)
         connected = ctypes.c_int()
 
-        ANC.getDeviceInfo(devNo, ctypes.byref(devType), ctypes.byref(id_), ctypes.byref(serialNo), ctypes.byref(address), ctypes.byref(connected))
+        ANC.getDeviceInfo(self.id, ctypes.byref(devType), ctypes.byref(id_), ctypes.byref(serialNo),
+                          ctypes.byref(address), ctypes.byref(connected))
         return devType.value, id_.value, serialNo.value.decode('utf-8'), address.value.decode('utf-8'), connected.value
-    
-    
-    def getFirmwareVersion(self):
-        '''
-        Retrieves the version of currently loaded firmware.
 
+    def getFirmwareVersion(self):
+        """
+        Retrieves the version of currently loaded firmware.
         Parameters
             None
         Returns
             version	Output: Version number
-        '''
+        """
         version = ctypes.c_int()
         ANC.getFirmwareVersion(self.device, ctypes.byref(version))
         return version.value
-    
-    
-    def getFrequency(self, axisNo):
-        '''
-        Reads back the frequency parameter of an axis.
 
+    def getFrequency(self, axisNo):
+        """
+        Reads back the frequency parameter of an axis.
         Parameters
             axisNo	Axis number (0 ... 2)
         Returns
             frequency	Output: Frequency in Hz
-        '''
+        """
         frequency = ctypes.c_double()
         ANC.getFrequency(self.device, axisNo, ctypes.byref(frequency))
         return frequency.value
-    
-    
-    def getPosition(self, axisNo):
-        '''
-        Retrieves the current actuator position. For linear type actuators the position unit is m; for goniometers and rotators it is degree.
 
+    def getPosition(self, axisNo):
+        """
+        Retrieves the current actuator position. For linear type actuators the position unit is m; for goniometers and rotators it is degree.
         Parameters
             axisNo	Axis number (0 ... 2)
         Returns
             position	Output: Current position [m] or [°]
-        '''
+        """
         position = ctypes.c_double()
         ANC.getPosition(self.device, axisNo, ctypes.byref(position))
         return position.value
-    
-    
-    def measureCapacitance(self, axisNo):
-        '''
-        Performs a measurement of the capacitance of the piezo motor and returns the result. If no motor is connected, the result will be 0. The function doesn't return before the measurement is complete; this will take a few seconds of time.
 
+    def measureCapacitance(self, axisNo):
+        """
+        Performs a measurement of the capacitance of the piezo motor and returns the result. If no motor is connected, the result will be 0. The function doesn't return before the measurement is complete; this will take a few seconds of time.
         Parameters
             axisNo	Axis number (0 ... 2)
         Returns
             cap	Output: Capacitance [F]
-        '''
+        """
         cap = ctypes.c_double()
         ANC.measureCapacitance(self.device, axisNo, ctypes.byref(cap))
         return cap.value
-   
 
     def saveParams(self):
-        '''
+        """
         Saves parameters to persistent flash memory in the device. They will be present as defaults after the next power-on. The following parameters are affected: Amplitude, frequency, actuator selections as well as Trigger and quadrature settings.
-
         Parameters
             None
         Returns
             None
-        '''
+        """
         ANC.saveParams(self.device)
-    
-    
-    def selectActuator(self, axisNo, actuator):
-        '''
-        Selects the actuator to be used for the axis from actuator presets.
 
+    def selectActuator(self, axisNo, actuator):
+        """
+        Selects the actuator to be used for the axis from actuator presets.
         Parameters
             axisNo	Axis number (0 ... 2)
             actuator	Actuator selection (0 ... 255)
@@ -393,124 +352,107 @@ class Positioner:
                 11: Test
         Returns
             None
-        '''
+        """
         ANC.selectActuator(self.device, axisNo, actuator)
-    
-    
-    def setAmplitude(self, axisNo, amplitude):
-        '''
-        Sets the amplitude parameter for an axis
 
+    def setAmplitude(self, axisNo, amplitude):
+        """
+        Sets the amplitude parameter for an axis
         Parameters
             axisNo	Axis number (0 ... 2)
             amplitude	Amplitude in V, internal resolution is 1 mV
         Returns
             None
-        '''
+        """
         ANC.setAmplitude(self.device, axisNo, ctypes.c_double(amplitude))
-   
 
     def setAxisOutput(self, axisNo, enable, autoDisable):
-        '''
+        """
         Enables or disables the voltage output of an axis.
-
         Parameters
             axisNo	Axis number (0 ... 2)
             enable	Enables (1) or disables (0) the voltage output.
             autoDisable	If the voltage output is to be deactivated automatically when end of travel is detected.
         Returns
             None
-        '''
+        """
         ANC.setAxisOutput(self.device, axisNo, enable, autoDisable)
-   
 
     def setDcVoltage(self, axisNo, voltage):
-        '''
+        """
         Sets the DC level on the voltage output when no sawtooth based motion is active.
-
             Parameters
             axisNo	Axis number (0 ... 2)
             voltage	DC output voltage [V], internal resolution is 1 mV
         Returns
-            None        
-        '''
+            None
+        """
         ANC.setDcVoltage(self.device, axisNo, ctypes.c_double(voltage))
- 
 
     def setFrequency(self, axisNo, frequency):
-        '''
+        """
         Sets the frequency parameter for an axis
-
         Parameters
             axisNo	Axis number (0 ... 2)
             frequency	Frequency in Hz, internal resolution is 1 Hz
         Returns
             None
-        '''
+        """
         ANC.setFrequency(self.device, axisNo, ctypes.c_double(frequency))
-        
-   
-    def setTargetPosition(self, axisNo, target):
-        '''
-        Sets the target position for automatic motion, see ANC_startAutoMove. For linear type actuators the position unit is m, for goniometers and rotators it is degree.
 
+    def setTargetPosition(self, axisNo, target):
+        """
+        Sets the target position for automatic motion, see ANC_startAutoMove. For linear type actuators the position unit is m, for goniometers and rotators it is degree.
         Parameters
             axisNo	Axis number (0 ... 2)
             target	Target position [m] or [°]. Internal resulution is 1 nm or 1 µ°.
         Returns
             None
-        '''
+        """
         ANC.setTargetPosition(self.device, axisNo, ctypes.c_double(target))
-        
-        
-    def setTargetRange(self, axisNo, targetRg):
-        '''
-        Defines the range around the target position where the target is considered to be reached.
 
+    def setTargetRange(self, axisNo, targetRg):
+        """
+        Defines the range around the target position where the target is considered to be reached.
         Parameters
             axisNo	Axis number (0 ... 2)
             targetRg	Target range [m] or [°]. Internal resulution is 1 nm or 1 µ°.
         Returns
             None
-        '''
+        """
         ANC.setTargetRange(self.device, axisNo, ctypes.c_double(targetRg))
-        
-        
-    def startAutoMove(self, axisNo, enable, relative):
-        '''
-        Switches automatic moving (i.e. following the target position) on or off
 
+    def startAutoMove(self, axisNo, enable, relative):
+        """
+        Switches automatic moving (i.e. following the target position) on or off
         Parameters
             axisNo	Axis number (0 ... 2)
             enable	Enables (1) or disables (0) automatic motion
             relative	If the target position is to be interpreted absolute (0) or relative to the current position (1)
         Returns
             None
-        '''
+        """
         ANC.startAutoMove(self.device, axisNo, enable, relative)
-        
-   
-    def startContinuousMove(self, axisNo, start, backward):
-        '''
-        Starts or stops continous motion in forward direction. Other kinds of motions are stopped.
 
+    def startContinuousMove(self, axisNo, start, backward):
+        """
+        Starts or stops continous motion in forward direction. Other kinds of motions are stopped.
         Parameters
             axisNo	Axis number (0 ... 2)
             start	Starts (1) or stops (0) the motion
             backward	If the move direction is forward (0) or backward (1)
         Returns
             None
-        '''
+        """
         ANC.startContinousMove(self.device, axisNo, start, backward)
-        
-    def startSingleStep(self, axisNo, backward):
-        '''
-        Triggers a single step in desired direction.
 
+    def startSingleStep(self, axisNo, backward):
+        """
+        Triggers a single step in desired direction.
         Parameters
             axisNo	Axis number (0 ... 2)
             backward	If the step direction is forward (0) or backward (1)
         Returns
             None
-        '''
+        """
         ANC.startSingleStep(self.device, axisNo, backward)


### PR DESCRIPTION
I was working with v4 and made some edits to the code so that it can address multiple controllers at the same time. It seems like a useful thing, so I figured I'd share it.

### PyANC350v4.py
 - Moved `Positioner.discover()` outside the `Positioner` class to be its own function.
 - Added a `Positioner.__del__()` method for safer garbage collection.
 - Removed unused imports.

### ANC350libv4.py
 - Made the DLL import more concise with `pathlib` instead of `os`.
 - Removed unused imports.

### example-v4.py
 - Refactored to match above changes.

Also, my IDE made a few changes to adhere to current PEP8 convention.